### PR TITLE
feat: add tracing spans for queries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,8 @@ clickhouse-derive = { version = "0.2.0", path = "derive" }
 clickhouse-types = { version = "0.1.0", path = "types" }
 
 thiserror = "2.0"
-serde = "1.0.106"
+serde = { version = "1.0.106", features = ["derive"] }
+serde_json = "1"
 bytes = "1.5.0"
 tokio = { version = "1.0.1", features = ["rt", "macros"] }
 http-body-util = "0.1.2"
@@ -147,15 +148,14 @@ chrono = { version = "0.4", optional = true, features = ["serde"] }
 bstr = { version = "1.11.0", default-features = false }
 quanta = { version = "0.12", optional = true }
 replace_with = { version = "0.1.7" }
+tracing = { version = "0.1" }
 
 [dev-dependencies]
 clickhouse-derive = { version = "0.2.0", path = "derive" }
 criterion = "0.6"
-serde = { version = "1.0.106", features = ["derive"] }
 tokio = { version = "1.0.1", features = ["full", "test-util"] }
 hyper = { version = "1.1", features = ["server"] }
 serde_bytes = "0.11.4"
-serde_json = "1"
 serde_repr = "0.1.7"
 uuid = { version = "1", features = ["v4", "serde"] }
 time = { version = "0.3.17", features = ["macros", "rand", "parsing"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ chrono = { version = "0.4", optional = true, features = ["serde"] }
 bstr = { version = "1.11.0", default-features = false }
 quanta = { version = "0.12", optional = true }
 replace_with = { version = "0.1.7" }
-tracing = { version = "0.1" }
+tracing = "0.1"
 
 [dev-dependencies]
 clickhouse-derive = { version = "0.2.0", path = "derive" }

--- a/src/insert.rs
+++ b/src/insert.rs
@@ -333,7 +333,7 @@ impl<T> Insert<T> {
         debug_assert!(matches!(self.state, InsertState::NotStarted { .. }));
         let (client, sql) = self.state.client_with_sql().unwrap(); // checked above
 
-        let span = tracing::debug_span!(
+        let span = tracing::info_span!(
             "clickhouse.insert",
             status = tracing::field::Empty,
             otel.status_code = tracing::field::Empty,

--- a/src/insert.rs
+++ b/src/insert.rs
@@ -333,6 +333,21 @@ impl<T> Insert<T> {
         debug_assert!(matches!(self.state, InsertState::NotStarted { .. }));
         let (client, sql) = self.state.client_with_sql().unwrap(); // checked above
 
+        let span = tracing::debug_span!(
+            "clickhouse.insert",
+            status = tracing::field::Empty,
+            otel.status_code = tracing::field::Empty,
+            otel.kind = "CLIENT",
+            db.system.name = "clickhouse",
+            db.query.text = sql,
+            db.response.returned_rows = tracing::field::Empty,
+            db.response.read_bytes = tracing::field::Empty,
+            db.response.read_rows = tracing::field::Empty,
+            db.response.written_bytes = tracing::field::Empty,
+            db.response.written_rows = tracing::field::Empty,
+        )
+        .entered();
+
         let mut url = Url::parse(&client.url).map_err(|err| Error::InvalidParams(err.into()))?;
         let mut pairs = url.query_pairs_mut();
         pairs.clear();
@@ -364,9 +379,13 @@ impl<T> Insert<T> {
             .map_err(|err| Error::InvalidParams(Box::new(err)))?;
 
         let future = client.http.request(request);
+        let span = span.exit();
         // TODO: introduce `Executor` to allow bookkeeping of spawned tasks.
-        let handle =
-            tokio::spawn(async move { Response::new(future, Compression::None).finish().await });
+        let handle = tokio::spawn(async move {
+            Response::new(future, Compression::None, span)
+                .finish()
+                .await
+        });
 
         self.state = InsertState::Active { handle, sender };
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ mod response;
 mod row;
 mod row_metadata;
 mod rowbinary;
+mod summary_header;
 #[cfg(feature = "inserter")]
 mod ticks;
 
@@ -320,6 +321,12 @@ impl Client {
     /// Starts a new SELECT/DDL query.
     pub fn query(&self, query: &str) -> query::Query {
         query::Query::new(self, query)
+    }
+
+    /// Starts a new SELECT/DDL query, with the `wait_end_of_query` setting enabled
+    /// to buffer the full query results on the server
+    pub fn query_buffered(&self, query: &str) -> query::Query {
+        query::Query::new_buffered(self, query)
     }
 
     /// Enables or disables [`Row`] data types validation against the database schema

--- a/src/query.rs
+++ b/src/query.rs
@@ -160,6 +160,7 @@ impl Query {
     }
 
     pub(crate) fn do_execute(self, read_only: bool) -> Result<Response> {
+        let query_formatted = format!("{}", self.sql_display());
         let query = self.sql.finish()?;
 
         let execution_span = tracing::debug_span!(
@@ -168,7 +169,7 @@ impl Query {
             otel.status_code = tracing::field::Empty,
             otel.kind = "CLIENT",
             db.system.name = "clickhouse",
-            db.query.text = query,
+            db.query.text = query_formatted,
             db.response.returned_rows = tracing::field::Empty,
             db.response.read_bytes = tracing::field::Empty,
             db.response.read_rows = tracing::field::Empty,

--- a/src/query.rs
+++ b/src/query.rs
@@ -163,7 +163,7 @@ impl Query {
         let query_formatted = format!("{}", self.sql_display());
         let query = self.sql.finish()?;
 
-        let execution_span = tracing::debug_span!(
+        let execution_span = tracing::info_span!(
             "clickhouse.query",
             status = tracing::field::Empty,
             otel.status_code = tracing::field::Empty,

--- a/src/query.rs
+++ b/src/query.rs
@@ -23,6 +23,7 @@ use crate::headers::with_authentication;
 pub struct Query {
     client: Client,
     sql: SqlBuilder,
+    wait_end_of_query: bool,
 }
 
 impl Query {
@@ -30,6 +31,15 @@ impl Query {
         Self {
             client: client.clone(),
             sql: SqlBuilder::new(template),
+            wait_end_of_query: false,
+        }
+    }
+
+    pub(crate) fn new_buffered(client: &Client, template: &str) -> Self {
+        Self {
+            client: client.clone(),
+            sql: SqlBuilder::new(template),
+            wait_end_of_query: true,
         }
     }
 
@@ -152,6 +162,22 @@ impl Query {
     pub(crate) fn do_execute(self, read_only: bool) -> Result<Response> {
         let query = self.sql.finish()?;
 
+        let execution_span = tracing::debug_span!(
+            "clickhouse.query",
+            status = tracing::field::Empty,
+            otel.status_code = tracing::field::Empty,
+            otel.kind = "CLIENT",
+            db.system.name = "clickhouse",
+            db.query.text = query,
+            db.response.returned_rows = tracing::field::Empty,
+            db.response.read_bytes = tracing::field::Empty,
+            db.response.read_rows = tracing::field::Empty,
+            db.response.written_bytes = tracing::field::Empty,
+            db.response.written_rows = tracing::field::Empty,
+            clickhouse.wait_end_of_query = self.wait_end_of_query,
+        )
+        .entered();
+
         let mut url =
             Url::parse(&self.client.url).map_err(|err| Error::InvalidParams(Box::new(err)))?;
         let mut pairs = url.query_pairs_mut();
@@ -178,6 +204,10 @@ impl Query {
             pairs.append_pair("compress", "1");
         }
 
+        if self.wait_end_of_query {
+            pairs.append_pair("wait_end_of_query", "1");
+        }
+
         for (name, value) in &self.client.options {
             pairs.append_pair(name, value);
         }
@@ -198,7 +228,11 @@ impl Query {
             .map_err(|err| Error::InvalidParams(Box::new(err)))?;
 
         let future = self.client.http.request(request);
-        Ok(Response::new(future, self.client.compression))
+        Ok(Response::new(
+            future,
+            self.client.compression,
+            execution_span.exit(),
+        ))
     }
 
     /// Similar to [`Client::with_option`], but for this particular query only.

--- a/src/response.rs
+++ b/src/response.rs
@@ -22,54 +22,108 @@ use crate::compression::lz4::Lz4Decoder;
 use crate::{
     compression::Compression,
     error::{Error, Result},
+    summary_header::Summary,
 };
+
+use tracing::{Instrument, Span};
 
 // === Response ===
 
 pub(crate) enum Response {
     // Headers haven't been received yet.
     // `Box<_>` improves performance by reducing the size of the whole future.
-    Waiting(ResponseFuture),
+    Waiting(ResponseFuture, Span),
     // Headers have been received, streaming the body.
-    Loading(Chunks),
+    Loading(Chunks, Span),
 }
 
 pub(crate) type ResponseFuture = Pin<Box<dyn Future<Output = Result<Chunks>> + Send>>;
 
 impl Response {
-    pub(crate) fn new(response: HyperResponseFuture, compression: Compression) -> Self {
-        Self::Waiting(Box::pin(async move {
-            let response = response.await?;
-            let status = response.status();
-            let body = response.into_body();
+    pub(crate) fn new(response: HyperResponseFuture, compression: Compression, span: Span) -> Self {
+        let inner_span = span.clone();
+        Self::Waiting(
+            Box::pin(async move {
+                let response = response.await?;
+                let status = response.status();
+                if let Some(summary_header) = response.headers().get("x-clickhouse-summary") {
+                    match serde_json::from_slice::<Summary>(summary_header.as_bytes()) {
+                        Ok(summary_header) => {
+                            if let Some(rows) = summary_header.result_rows {
+                                inner_span.record("db.response.returned_rows", rows);
+                            }
+                            if let Some(rows) = summary_header.read_rows {
+                                inner_span.record("db.response.read_rows", rows);
+                            }
+                            if let Some(rows) = summary_header.written_rows {
+                                inner_span.record("db.response.written_rows", rows);
+                            }
+                            if let Some(bytes) = summary_header.read_bytes {
+                                inner_span.record("db.response.read_bytes", bytes);
+                            }
+                            if let Some(bytes) = summary_header.written_bytes {
+                                inner_span.record("db.response.written_bytes", bytes);
+                            }
+                            tracing::trace!(
+                                read_rows = summary_header.read_rows,
+                                read_bytes = summary_header.read_bytes,
+                                written_rows = summary_header.written_bytes,
+                                written_bytes = summary_header.written_rows,
+                                total_rows_to_read = summary_header.total_rows_to_read,
+                                result_rows = summary_header.result_rows,
+                                result_bytes = summary_header.result_bytes,
+                                elapsed_ns = summary_header.elapsed_ns,
+                                "finished processing query"
+                            )
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                "invalid x-clickhouse-summary header returned: {:?}, {:?}",
+                                e,
+                                summary_header
+                            );
+                        }
+                    }
+                }
+                let body = response.into_body();
 
-            if status == StatusCode::OK {
-                // More likely to be successful, start streaming.
-                // It still can fail, but we'll handle it in `DetectDbException`.
-                Ok(Chunks::new(body, compression))
-            } else {
-                // An instantly failed request.
-                Err(collect_bad_response(status, body, compression).await)
-            }
-        }))
+                inner_span.record("status", status.as_u16());
+
+                if status == StatusCode::OK {
+                    inner_span.record("otel.status_code", "OK");
+                    // More likely to be successful, start streaming.
+                    // It still can fail, but we'll handle it in `DetectDbException`.
+                    Ok(Chunks::new(body, compression))
+                } else {
+                    inner_span.record("otel.status_code", "ERROR");
+                    // An instantly failed request.
+                    Err(collect_bad_response(status, body, compression)
+                        .instrument(inner_span)
+                        .await)
+                }
+            }),
+            span,
+        )
     }
 
     pub(crate) fn into_future(self) -> ResponseFuture {
         match self {
-            Self::Waiting(future) => future,
-            Self::Loading(_) => panic!("response is already streaming"),
+            Self::Waiting(future, span) => Box::pin(future.instrument(span)),
+            Self::Loading(_, _) => panic!("response is already streaming"),
         }
     }
 
     pub(crate) async fn finish(&mut self) -> Result<()> {
-        let chunks = loop {
+        let (chunks, span) = loop {
             match self {
-                Self::Waiting(future) => *self = Self::Loading(future.await?),
-                Self::Loading(chunks) => break chunks,
+                Self::Waiting(future, span) => {
+                    *self = Self::Loading(future.instrument(span.clone()).await?, span.clone())
+                }
+                Self::Loading(chunks, span) => break (chunks, span),
             }
         };
 
-        while chunks.try_next().await?.is_some() {}
+        while chunks.try_next().instrument(span.clone()).await?.is_some() {}
         Ok(())
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -93,7 +93,7 @@ impl Response {
                     inner_span.record("otel.status_code", "OK");
                     // More likely to be successful, start streaming.
                     // It still can fail, but we'll handle it in `DetectDbException`.
-                    Ok(Chunks::new(body, compression))
+                    Ok(Chunks::new(body, compression, inner_span))
                 } else {
                     inner_span.record("otel.status_code", "ERROR");
                     // An instantly failed request.
@@ -195,23 +195,32 @@ pub(crate) struct Chunk {
 
 // * Uses `Option<_>` to make this stream fused.
 // * Uses `Box<_>` in order to reduce the size of cursors.
-pub(crate) struct Chunks(Option<Box<DetectDbException<Decompress<IncomingStream>>>>);
+pub(crate) struct Chunks {
+    stream: Option<Box<DetectDbException<Decompress<IncomingStream>>>>,
+    span: Option<Span>,
+}
 
 impl Chunks {
-    fn new(stream: Incoming, compression: Compression) -> Self {
+    fn new(stream: Incoming, compression: Compression, span: Span) -> Self {
         let stream = IncomingStream(stream);
         let stream = Decompress::new(stream, compression);
         let stream = DetectDbException(stream);
-        Self(Some(Box::new(stream)))
+        Self {
+            stream: Some(Box::new(stream)),
+            span: Some(span),
+        }
     }
 
     pub(crate) fn empty() -> Self {
-        Self(None)
+        Self {
+            stream: None,
+            span: None,
+        }
     }
 
     #[cfg(feature = "futures03")]
     pub(crate) fn is_terminated(&self) -> bool {
-        self.0.is_none()
+        self.stream.is_none()
     }
 }
 
@@ -219,16 +228,19 @@ impl Stream for Chunks {
     type Item = Result<Chunk>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let guard = self.span.take().map(|s| s.entered());
         // We use `take()` to make the stream fused, including the case of panics.
-        if let Some(mut stream) = self.0.take() {
+        if let Some(mut stream) = self.stream.take() {
             let res = Pin::new(&mut stream).poll_next(cx);
 
             if matches!(res, Poll::Pending | Poll::Ready(Some(Ok(_)))) {
-                self.0 = Some(stream);
+                self.stream = Some(stream);
+                self.span = guard.map(|g| g.exit());
             }
 
             res
         } else {
+            self.span = guard.map(|g| g.exit());
             Poll::Ready(None)
         }
     }

--- a/src/response.rs
+++ b/src/response.rs
@@ -78,9 +78,9 @@ impl Response {
                         }
                         Err(e) => {
                             tracing::warn!(
-                                "invalid x-clickhouse-summary header returned: {:?}, {:?}",
-                                e,
-                                summary_header
+                                error = &e as &dyn std::error::Error,
+                                ?summary_header,
+                                "invalid x-clickhouse-summary header returned",
                             );
                         }
                     }

--- a/src/response.rs
+++ b/src/response.rs
@@ -64,7 +64,7 @@ impl Response {
                             if let Some(bytes) = summary_header.written_bytes {
                                 inner_span.record("db.response.written_bytes", bytes);
                             }
-                            tracing::trace!(
+                            tracing::debug!(
                                 read_rows = summary_header.read_rows,
                                 read_bytes = summary_header.read_bytes,
                                 written_rows = summary_header.written_bytes,

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -1,4 +1,4 @@
-use std::fmt::{self, Display, Write};
+use std::fmt::{self, Display};
 
 use crate::{
     error::{Error, Result},
@@ -13,7 +13,11 @@ pub(crate) mod ser;
 
 #[derive(Debug, Clone)]
 pub(crate) enum SqlBuilder {
-    InProgress(Vec<Part>, Option<String>),
+    InProgress {
+        template: String,
+        parts: Vec<Part>,
+        format_opt: Option<String>,
+    },
     Failed(String),
 }
 
@@ -28,15 +32,13 @@ pub(crate) enum Part {
 impl fmt::Display for SqlBuilder {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            SqlBuilder::InProgress(parts, output_format_opt) => {
-                for part in parts {
-                    match part {
-                        Part::Arg => f.write_char('?')?,
-                        Part::Fields => f.write_str("?fields")?,
-                        Part::Text(text) => f.write_str(text)?,
-                    }
-                }
-                if let Some(output_format) = output_format_opt {
+            SqlBuilder::InProgress {
+                template,
+                format_opt,
+                ..
+            } => {
+                f.write_str(template)?;
+                if let Some(output_format) = format_opt {
                     f.write_str(&format!(" FORMAT {output_format}"))?
                 }
             }
@@ -49,6 +51,7 @@ impl fmt::Display for SqlBuilder {
 impl SqlBuilder {
     pub(crate) fn new(template: &str) -> Self {
         let mut parts = Vec::new();
+        let owned_template = String::from(template);
         let mut rest = template;
         while let Some(idx) = rest.find('?') {
             if rest[idx + 1..].starts_with('?') {
@@ -72,17 +75,21 @@ impl SqlBuilder {
             parts.push(Part::Text(rest.to_string()));
         }
 
-        SqlBuilder::InProgress(parts, None)
+        SqlBuilder::InProgress {
+            parts,
+            template: owned_template,
+            format_opt: None,
+        }
     }
 
     pub(crate) fn set_output_format(&mut self, format: impl Into<String>) {
-        if let Self::InProgress(_, format_opt) = self {
+        if let Self::InProgress { format_opt, .. } = self {
             *format_opt = Some(format.into());
         }
     }
 
     pub(crate) fn bind_arg(&mut self, value: impl Bind) {
-        let Self::InProgress(parts, _) = self else {
+        let Self::InProgress { parts, .. } = self else {
             return;
         };
 
@@ -100,7 +107,7 @@ impl SqlBuilder {
     }
 
     pub(crate) fn bind_fields<T: Row>(&mut self) {
-        let Self::InProgress(parts, _) = self else {
+        let Self::InProgress { parts, .. } = self else {
             return;
         };
 
@@ -116,7 +123,7 @@ impl SqlBuilder {
     pub(crate) fn finish(mut self) -> Result<String> {
         let mut sql = String::new();
 
-        if let Self::InProgress(parts, _) = &self {
+        if let Self::InProgress { parts, .. } = &self {
             for part in parts {
                 match part {
                     Part::Text(text) => sql.push_str(text),
@@ -133,8 +140,8 @@ impl SqlBuilder {
         }
 
         match self {
-            Self::InProgress(_, output_format_opt) => {
-                if let Some(output_format) = output_format_opt {
+            Self::InProgress { format_opt, .. } => {
+                if let Some(output_format) = format_opt {
                     sql.push_str(&format!(" FORMAT {output_format}"))
                 }
                 Ok(sql)

--- a/src/summary_header.rs
+++ b/src/summary_header.rs
@@ -1,0 +1,36 @@
+use serde::de::Error;
+use serde::{Deserialize, Deserializer};
+
+#[derive(Debug, serde::Deserialize)]
+pub(crate) struct Summary {
+    #[serde(deserialize_with = "int_in_string")]
+    pub read_rows: Option<usize>,
+    #[serde(deserialize_with = "int_in_string")]
+    pub read_bytes: Option<usize>,
+    #[serde(deserialize_with = "int_in_string")]
+    pub written_rows: Option<usize>,
+    #[serde(deserialize_with = "int_in_string")]
+    pub written_bytes: Option<usize>,
+    #[serde(deserialize_with = "int_in_string")]
+    pub total_rows_to_read: Option<usize>,
+    #[serde(deserialize_with = "int_in_string")]
+    pub result_rows: Option<usize>,
+    #[serde(deserialize_with = "int_in_string")]
+    pub result_bytes: Option<usize>,
+    #[serde(deserialize_with = "int_in_string")]
+    pub elapsed_ns: Option<usize>,
+}
+
+fn int_in_string<'de, D>(deser: D) -> Result<Option<usize>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    if let Some(string) = Option::<&str>::deserialize(deser)? {
+        let value: usize = string
+            .parse()
+            .map_err(|_| D::Error::custom("invalid integer"))?;
+        Ok(Some(value))
+    } else {
+        Ok(None)
+    }
+}


### PR DESCRIPTION
## Summary

Internal review prior to sending this upstream. Changes:

- Create tracing spans for clickhouse queries (using `tracing::Span`)
- Parse the `X-ClickHouse-Summary` header (which is JSON) and attach key fields as attributes to the tracing span
- Support buffering queries on the server, which is required to get accurate results in `X-Clickhouse-Summary`